### PR TITLE
Add option for create_log_group, default to False

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -35,6 +35,7 @@ BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
 LEGACY_URL = os.environ.get("API_URL", None)
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 LOG_GROUP = os.environ.get("LOG_GROUP", "platform-dev")
+CREATE_LOG_GROUP = os.environ.get("CREATE_LOG_GROUP", "").lower() == "true"
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", None)
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")

--- a/utils/host_delete_logging.py
+++ b/utils/host_delete_logging.py
@@ -15,9 +15,12 @@ def config_cloudwatch(logger):
     CW_SESSION = Session(aws_access_key_id=config.AWS_ACCESS_KEY_ID,
                          aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY,
                          region_name=config.AWS_REGION)
-    cw_handler = watchtower.CloudWatchLogHandler(boto3_session=CW_SESSION,
-                                                 log_group=config.LOG_GROUP,
-                                                 stream_name=config.NAMESPACE)
+    cw_handler = watchtower.CloudWatchLogHandler(
+        boto3_session=CW_SESSION,
+        log_group=config.LOG_GROUP,
+        stream_name=config.NAMESPACE,
+        create_log_group=config.CREATE_LOG_GROUP
+    )
     cw_handler.setFormatter(LogstashFormatterV1())
     logger.addHandler(cw_handler)
 


### PR DESCRIPTION
In app-sre, apps are not given access to create their log group. The log group already exists for them.

Since in our current environments the log group already exists as well, this shouldn't have much impact.